### PR TITLE
Sophie/fixes

### DIFF
--- a/Resources/Private/FormFramework/Frontend/Partials/Checkbox.html
+++ b/Resources/Private/FormFramework/Frontend/Partials/Checkbox.html
@@ -58,8 +58,9 @@
         />
 
         <f:comment><!-- Visual replacement of the checkbox via SVG --></f:comment>
-        <svg class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
-            <use href="#checkmark"></use>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26.512 23.211" class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
+            <path fill="000000"
+                  d="M9.131 23.206L0 13.888l2.857-2.8 6.05 6.174L23.452-.006l3.06 2.576z"/>
         </svg>
     </f:section>
 

--- a/Resources/Private/FormFramework/Frontend/Partials/Field/Error.html
+++ b/Resources/Private/FormFramework/Frontend/Partials/Field/Error.html
@@ -19,10 +19,7 @@
         </f:variable>
 
         <p id="{element.uniqueIdentifier}-error"
-           class="Form__error"{f:if(condition: errorCount, else: ' hidden')}>
-            <svg width="24" height="24" class="Form__error-icon" aria-hidden="true" focusable="false">
-                <use href="#warning-sign"></use>
-            </svg>
+           class="Form__error"{f:if(condition: {errorCount}, else: ' hidden')}>
             {errorContent -> twforms:format.trim() -> f:format.raw()}
         </p>
     </f:if>

--- a/Resources/Private/FormFramework/Frontend/Partials/Form/Validation.html
+++ b/Resources/Private/FormFramework/Frontend/Partials/Form/Validation.html
@@ -54,17 +54,13 @@
             <f:variable name="headingContent"
                         value="{f:if(condition: '{count} == 1', then: '{f:translate(key: headingKeySingle)}', else: '{f:translate(key: headingKeyMultiple, arguments: \'{0: count}\')}')}"/>
 
-            <div class="Form__error-navigation-heading-wrapper">
-                <svg width="48" height="48" aria-hidden="true" focusable="false" class="Form__error-navigation-icon">
-                    <use href="#warning-sign"></use>
-                </svg>
-                <h2 class="Form__error-heading"
-                    id="{form.identifier}-errors"
-                    data-heading-single="{f:translate(key: headingKeySingle)}"
-                    data-heading-multiple="{f:translate(key: headingKeyMultiple)}">
-                    {headingContent}
-                </h2>
-            </div>
+            <h2 class="Form__error-heading"
+                id="{form.identifier}-errors"
+                data-heading-single="{f:translate(key: headingKeySingle)}"
+                data-heading-multiple="{f:translate(key: headingKeyMultiple)}">
+                {headingContent}
+            </h2>
+
             <ol class="Form__error-summary">
                 <f:for each="{validationResults.flattenedErrors}" as="propertyErrors" key="elementIdentifier">
                     <f:variable name="element"

--- a/Resources/Private/FormFramework/Frontend/Partials/Page.html
+++ b/Resources/Private/FormFramework/Frontend/Partials/Page.html
@@ -11,7 +11,6 @@
       xmlns:twforms="http://typo3.org/ns/Tollwerk/TwForms/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-
     <formvh:renderRenderable renderable="{page}">
         <f:if condition="{page.parentRenderable.renderingOptions.enableStatusDisplay}">
             <f:render partial="Form/Status" arguments="{form: form, page: page}"/>
@@ -26,10 +25,18 @@
             <f:if condition="{page.rootForm.pages -> f:count()} > 1">
                 <f:then>
                     <f:variable name="isMultiStep" value="true" />
+                    <f:variable name="pageNumber" value="{page.index + 1}" />
                     <fieldset class="FormPage">
                         <legend class="FormPage__legend"
                                 id="{form.identifier}-{page.identifier}">
-                            <h3>{formvh:translateElementProperty(element: page, property: 'label')}</h3>
+                            <f:if condition="{page.label} != ''">
+                                <f:then>
+                                    <h3>{formvh:translateElementProperty(element: page, property: 'label')}</h3>
+                                </f:then>
+                                <f:else>
+                                    <h3 class="hide-element">{f:translate(key: 'form.page', extensionName: 'TwForms', arguments: '{0: pageNumber}')}</h3>
+                                </f:else>
+                            </f:if>
                         </legend>
                         <f:for each="{page.elements}" as="element">
                             <f:render partial="{element.templateName}"

--- a/Resources/Private/FormFramework/Frontend/Partials/RadioButton.html
+++ b/Resources/Private/FormFramework/Frontend/Partials/RadioButton.html
@@ -37,8 +37,8 @@
                                 additionalAttributes="{additionalAttributes}"
                         />
                         <f:comment><!-- Visual replacement of the radio button via SVG --></f:comment>
-                        <svg class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
-                            <use href="#circle"></use>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
+                            <circle fill="000000" cx="40" cy="40" r="40"/>
                         </svg>
                         <f:render section="InlineLabel" contentAs="label">
                             {formvh:translateElementProperty(element: element, property: '{0: \'options\', 1: value}')}

--- a/Resources/Private/FormFramework/Frontend/Templates/Form.html
+++ b/Resources/Private/FormFramework/Frontend/Templates/Form.html
@@ -24,23 +24,4 @@
             </formvh:form>
         </formvh:renderRenderable>
     </formvh:renderRenderable>
-
-    <svg xmlns="http://www.w3.org/2000/svg"
-         display="none">
-        <symbol id="warning-sign"
-                viewBox="0 0 50 50">
-            <path fill="#ad0c01"
-                  d="M21.9-.1C9.7-.1-.1 9.8-.1 22S9.8 44.1 22 44.1 44 34.2 44 22C44 9.8 34.1-.1 21.9-.1zM24.1 33h-4.4v-4.4h4.4V33zm0-8.8h-4.4V11h4.4v13.2z"/>
-        </symbol>
-        <symbol id="checkmark"
-                viewBox="0 0 26.512 23.211">
-            <path fill="000000"
-                  d="M9.131 23.206L0 13.888l2.857-2.8 6.05 6.174L23.452-.006l3.06 2.576z"/>
-        </symbol>
-        <symbol id="circle"
-                viewBox="0 0 80 80">
-            <circle fill="000000"
-                    cx="40" cy="40" r="40"/>
-        </symbol>
-    </svg>
 </html>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -20,6 +20,10 @@
                 <source>Next</source>
                 <target state="translated">Weiter</target>
             </trans-unit>
+            <trans-unit id="form.page" approved="yes">
+                <source>Page %s</source>
+                <target state="translated">Seite %s</target>
+            </trans-unit>
             <trans-unit id="form.required" approved="yes">
                 <source>(required)</source>
                 <target state="translated">(erforderlich)</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -16,6 +16,9 @@
             <trans-unit id="form.next">
                 <source>Next</source>
             </trans-unit>
+            <trans-unit id="form.page">
+                <source>Page %s</source>
+            </trans-unit>
             <trans-unit id="form.required">
                 <source>(required)</source>
             </trans-unit>

--- a/Resources/Private/Powermail/Partials/Form/Field/Check.html
+++ b/Resources/Private/Powermail/Partials/Form/Field/Check.html
@@ -77,9 +77,10 @@
                     </f:else>
                 </f:if>
 
-                <f:comment><!-- Visual replacement of the radio button via SVG --></f:comment>
-                <svg class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
-                    <use href="#checkmark"></use>
+                <f:comment><!-- Visual replacement of the checkbox via SVG --></f:comment>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26.512 23.211" class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
+                    <path fill="000000"
+                          d="M9.131 23.206L0 13.888l2.857-2.8 6.05 6.174L23.452-.006l3.06 2.576z"/>
                 </svg>
 
                 <f:comment><!-- Label --></f:comment>

--- a/Resources/Private/Powermail/Partials/Form/Field/Radio.html
+++ b/Resources/Private/Powermail/Partials/Form/Field/Radio.html
@@ -44,8 +44,8 @@
           </f:if>
 
           <f:comment><!-- Visual replacement of the radio button via SVG --></f:comment>
-          <svg class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
-              <use href="#circle"></use>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" class="Icon" width="24" height="24" aria-hidden="true" focusable="false">
+              <circle fill="000000" cx="40" cy="40" r="40"/>
           </svg>
 
           <f:comment><!-- The radio button label text --></f:comment>

--- a/Resources/Private/Powermail/Partials/Form/FieldError.html
+++ b/Resources/Private/Powermail/Partials/Form/FieldError.html
@@ -2,14 +2,8 @@
 
 <f:form.validationResults>
   <p class="Form__error" id="error-for-powermail-field-{formId}-{field.marker}"{f:if(condition: validationResults.flattenedErrors, else: ' hidden')}>
-    <svg width="24" height="24" class="Form__error-icon Form__error-icon--js" aria-hidden="true" focusable="false">
-      <use href="#warning-sign"></use>
-    </svg>
     <f:if condition="{validationResults.flattenedErrors}">
       <f:for each="{validationResults.flattenedErrors.mail}" as="error">
-          <svg width="24" height="24" class="Form__error-icon" aria-hidden="true" focusable="false">
-              <use href="#warning-sign"></use>
-          </svg>
           <f:if condition="{field.marker} == {error.arguments.marker}">
               <f:translate key="validationerror_{error.message}">
                   {error.message}

--- a/Resources/Private/Powermail/Partials/Misc/FormError.html
+++ b/Resources/Private/Powermail/Partials/Misc/FormError.html
@@ -14,7 +14,7 @@
     <f:variable name="title"
                 value="{twforms:form.title(form: form, pattern: pattern, errors: count)}"/>
 
-    <nav class="Form__error-navigation powermail_message powermail_message_error"
+    <nav class="Form__error-navigation powermail_message powermail_message_error{f:if(condition: '{validationResults.flattenedErrors}', then: ' Form__error-navigation--visible', else: '')}"
          aria-label="{f:translate(key: 'LLL:EXT:tw_forms/Resources/Private/Language/locallang.xlf:form.nav.errors')}"
          tabindex="-1"
          data-title="{title.default}"
@@ -28,67 +28,57 @@
         <f:variable name="headingContent"
                     value="{f:if(condition: '{count} == 1', then: '{f:translate(key: headingKeySingle)}', else: '{f:translate(key: headingKeyMultiple, arguments: \'{0: count}\')}')}"/>
 
-        <div class="Form__error-navigation-heading-wrapper">
-            <svg width="48" height="48" aria-hidden="true" focusable="false" class="Form__error-navigation-icon">
-              <use href="#warning-sign" />
-            </svg>
-            <h2 class="Form__error-heading"
-                id="{formId}-errors"
-                data-heading-single="{f:translate(key: headingKeySingle)}"
-                data-heading-multiple="{f:translate(key: headingKeyMultiple)}">
-              {headingContent}
-            </h2>
-        </div>
+        <h2 class="Form__error-heading"
+            id="{formId}-errors"
+            data-heading-single="{f:translate(key: headingKeySingle)}"
+            data-heading-multiple="{f:translate(key: headingKeyMultiple)}">
+          {headingContent}
+        </h2>
 
         <ol class="Form__error-summary">
-      <f:if condition="{validationResults.flattenedErrors}">
-        <f:for each="{validationResults.flattenedErrors}" as="errors">
-          <f:for each="{errors}" as="singleError">
-            <li class="Form__error-description">
-              <f:if condition="{singleError.message} == 'spam_details'">
-                <f:then>
-                  <f:translate key="validationerror_spam" />
-                  {singleError.arguments.spamfactor}
-
-                  <f:translate key="validationerror_{singleError.message}"
-                    >{singleError.message}</f:translate
-                  >
-                </f:then>
-                <f:else>
-                  <f:if condition="{singleError.arguments.marker}">
-                    <f:if condition="{vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'type')} == 'check'
-                                            || {vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'type')} == 'radio'"
-                    >
-                      <f:then>
-                          <a href="#{formId}-powermail-field-{singleError.arguments.marker}-1"
-                             class="Form__error-link"
-                             data-field-title="{vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'title')}">
-                              <vh:getter.getFieldPropertyFromMarkerAndForm
-                                      marker="{singleError.arguments.marker}"
-                                      form="{form}"
-                                      property="title"/>:
-                              <f:translate key="validationerror_{singleError.message}">{singleError.message}</f:translate>
-                          </a>
-                      </f:then>
-                      <f:else>
-                          <a href="#{formId}-powermail-field-{singleError.arguments.marker}"
-                             class="Form__error-link"
-                             data-field-title="{vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'title')}">
-                              <vh:getter.getFieldPropertyFromMarkerAndForm
-                                      marker="{singleError.arguments.marker}"
-                                      form="{form}"
-                                      property="title"/>:
-                              <f:translate key="validationerror_{singleError.message}">{singleError.message}</f:translate>
-                          </a>
-                      </f:else>
-                    </f:if>
-                  </f:if>
-                </f:else>
-              </f:if>
-            </li>
-          </f:for>
-        </f:for>
-      </f:if>
-    </ol>
+            <f:if condition="{validationResults.flattenedErrors}">
+                <f:for each="{validationResults.flattenedErrors}" as="errors">
+                    <f:for each="{errors}" as="singleError">
+                        <li class="Form__error-description">
+                            <f:if condition="{singleError.message} == 'spam_details'">
+                                <f:then>
+                                    <f:translate key="validationerror_spam" />
+                                    {singleError.arguments.spamfactor}
+                                    <f:translate key="validationerror_{singleError.message}">{singleError.message}</f:translate>
+                                </f:then>
+                                <f:else>
+                                    <f:if condition="{singleError.arguments.marker}">
+                                        <f:if condition="{vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'type')} == 'check'
+                                            || {vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'type')} == 'radio'">
+                                            <f:then>
+                                                <a href="#{formId}-powermail-field-{singleError.arguments.marker}-1"
+                                                   class="Form__error-link"
+                                                   data-field-title="{vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'title')}">
+                                                    <vh:getter.getFieldPropertyFromMarkerAndForm marker="{singleError.arguments.marker}"
+                                                                                                 form="{form}"
+                                                                                                 property="title"/>:
+                                                    <f:translate key="validationerror_{singleError.message}">{singleError.message}</f:translate>
+                                                </a>
+                                            </f:then>
+                                            <f:else>
+                                                <a href="#{formId}-powermail-field-{singleError.arguments.marker}"
+                                                   class="Form__error-link"
+                                                   data-field-title="{vh:getter.getFieldPropertyFromMarkerAndForm(marker: singleError.arguments.marker, form: form, property: 'title')}">
+                                                    <vh:getter.getFieldPropertyFromMarkerAndForm
+                                                            marker="{singleError.arguments.marker}"
+                                                            form="{form}"
+                                                            property="title"/>:
+                                                    <f:translate key="validationerror_{singleError.message}">{singleError.message}</f:translate>
+                                                </a>
+                                            </f:else>
+                                        </f:if>
+                                    </f:if>
+                                </f:else>
+                            </f:if>
+                        </li>
+                    </f:for>
+                </f:for>
+            </f:if>
+        </ol>
     </nav>
 </f:form.validationResults>

--- a/Resources/Private/Powermail/Templates/Form/Form.html
+++ b/Resources/Private/Powermail/Templates/Form/Form.html
@@ -51,25 +51,6 @@ Render Powermail Form
 
                     <f:render partial="Misc/HoneyPod" arguments="{form:form}"/>
                 </f:form>
-
-                <svg xmlns="http://www.w3.org/2000/svg"
-             display="none">
-            <symbol id="warning-sign"
-                    viewBox="0 0 50 50">
-                <path fill="#ad0c01"
-                      d="M21.9-.1C9.7-.1-.1 9.8-.1 22S9.8 44.1 22 44.1 44 34.2 44 22C44 9.8 34.1-.1 21.9-.1zM24.1 33h-4.4v-4.4h4.4V33zm0-8.8h-4.4V11h4.4v13.2z"/>
-            </symbol>
-            <symbol id="checkmark"
-                    viewBox="0 0 26.512 23.211">
-                <path fill="000000"
-                      d="M9.131 23.206L0 13.888l2.857-2.8 6.05 6.174L23.452-.006l3.06 2.576z"/>
-            </symbol>
-            <symbol id="circle"
-                    viewBox="0 0 80 80">
-                <circle fill="000000"
-                        cx="40" cy="40" r="40"/>
-            </symbol>
-        </svg>
             </div>
         </f:then>
         <f:else>

--- a/Resources/Private/Powermail/Templates/Form/Form.html
+++ b/Resources/Private/Powermail/Templates/Form/Form.html
@@ -26,8 +26,8 @@ Render Powermail Form
                         additionalAttributes="{aria-labelledby: '{formId}-heading'}"
                         class="{settings.styles.framework.formClasses} powermail_form powermail_form_{form.uid}{f:if(condition: '{form.css}', then: ' {form.css}')} {vh:misc.morestepClass(activate:settings.main.moresteps)}">
 
-                    <f:comment><!-- Render a form heading if Backend doesn't say 'noLabel' --></f:comment>
-                    <h2 class="{f:if(condition: '{form.css} == \'nolabel\'', then: 'hide-element')}"
+                    <f:comment><!-- Render a form heading and hide it visually if 'noLabel' is set --></f:comment>
+                    <h2 class="Powermail__heading {f:if(condition: '{form.css} == \'nolabel\'', then: ' hide-element')}"
                         id="{formId}-heading">
                         {form.title}
                     </h2>

--- a/Resources/Public/Css/twforms.css
+++ b/Resources/Public/Css/twforms.css
@@ -109,18 +109,6 @@ select {
 	}
 }
 
-/* Modern approach to focus styling: Only visible for keyboard users */
-@supports (selector(:focus-visible)) {
-	.FormField__input:focus, .FormField__textarea:focus {
-		outline: none;
-	}
-
-	.FormField__input:focus-visible, .FormField__textarea:focus-visible {
-		outline: 2px solid var(--color-highlight);
-		outline-offset: 2px;
-	}
-}
-
 .FormField__description {
 	margin-block: .5em 0;
 

--- a/Resources/Public/Css/twforms.css
+++ b/Resources/Public/Css/twforms.css
@@ -68,11 +68,13 @@ select {
 }
 
 /* Lobotomized owl selector doesn't work in this setup due to DOM manipulations */
-.FormPage .FormField {
-	margin-top: 1em;
+.FormPage {
+	& .FormField {
+		margin-top: 1em;
 
-	&:first-child {
-		margin-top: 0;
+		&:first-of-type {
+			margin-top: 0;
+		}
 	}
 }
 
@@ -84,7 +86,11 @@ select {
 	font-weight: bold;
 	font-size: 1.5rem;
 
-	& ~ .FormField:first-of-type {
+	& h3, h4 {
+		margin: 0;
+	}
+
+	& + .FormField {
 		margin-top: 0;
 	}
 }
@@ -200,18 +206,6 @@ select {
 	}
 }
 
-/* Modern approach to focus styling: Only visible for keyboard users */
-@supports (selector(:focus-visible)) {
-	.Form__button:focus {
-		outline: none;
-	}
-
-	.Form__button:focus-visible {
-		outline: 2px solid var(--color-highlight);
-		outline-offset: 2px;
-	}
-}
-
 /* Checkboxes and radio buttons
    ========================================================================== */
 
@@ -276,18 +270,6 @@ select {
 	outline-offset: 2px;
 }
 
-/* Modern approach to focus styling: Only visible for keyboard users */
-@supports (selector(:focus-visible)) {
-	.CustomInput .FormField__input:focus + .Icon {
-		outline: none;
-	}
-
-	.CustomInput .FormField__input:focus-visible + .Icon {
-		outline: 2px solid var(--color-highlight);
-		outline-offset: 2px;
-	}
-}
-
 /* Support window high contrast mode */
 @media screen and (forced-colors: active) {
 	.CustomInput .Icon {
@@ -303,12 +285,14 @@ select {
    ========================================================================== */
 
 .Form__error {
-	display: flex;
-	align-items: center;
-	gap: .125em;
-	margin-block: .5em;
+	display: block;
 
-	color: var(--color-error);
+	padding-left: 2rem;
+	margin-block: 0 .5em;
+
+	background: 0 url(../Graphics/Warning.svg) no-repeat;
+	background-size: 1em;
+	color: #c92228;
 
 	font-weight: 700;
 
@@ -316,47 +300,33 @@ select {
 		display: none;
 		margin: 0;
 	}
-
-	& p {
-		margin: 0;
-	}
 }
 
 .Form__error-navigation {
-	border: 5px solid var(--color-error-dark);
 	padding: 1.5rem;
+	border: 5px solid var(--color-error-dark);
 
-	& svg {
-		display: inline-flex;
-	}
-}
-
-.Form__error-navigation-heading-wrapper {
-	display: flex;
-	align-items: center;
-	gap: .5em;
-
-	& .Form__error-navigation-icon {
-		flex-shrink: 0;
+	&.Form__error-navigation--visible {
+		margin-bottom: 1rem;
 	}
 }
 
 .Form__error-heading {
+	padding-left: 2.5em;
 	margin: 0;
-}
 
-.Form__error-icon.Form__error-icon--js {
-	display: none;
+	background: url(../Graphics/Warning.svg) 0 0 no-repeat;
+	background-size: 2em;
+	color: var(--color-error);
+
+	-ms-hyphens: auto;
+	hyphens: auto;
 }
 
 .FormField--has-error {
 	& .FormField__input, & .FormField__textarea, & .CustomInput .Icon {
 		border: 3px solid var(--color-error);
 		box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--color-error);
-	}
-
-	& .Form__error-icon.Form__error-icon--js {
-		display: block;
 	}
 }
 

--- a/Resources/Public/Graphics/Checkmark.svg
+++ b/Resources/Public/Graphics/Checkmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26.512 23.211" width="24" height="24" aria-hidden="true" focusable="false">
+    <path fill="000000" d="M9.131 23.206L0 13.888l2.857-2.8 6.05 6.174L23.452-.006l3.06 2.576z"/>
+</svg>

--- a/Resources/Public/Graphics/Circle.svg
+++ b/Resources/Public/Graphics/Circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="24" height="24" aria-hidden="true" focusable="false">
+    <circle fill="000000" cx="40" cy="40" r="40"/>
+</svg>

--- a/Resources/Public/Graphics/Warning.svg
+++ b/Resources/Public/Graphics/Warning.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" width="24" height="24" aria-hidden="true" focusable="false">
+    <path fill="#ad0c01" d="M21.9-.1C9.7-.1-.1 9.8-.1 22S9.8 44.1 22 44.1 44 34.2 44 22C44 9.8 34.1-.1 21.9-.1zM24.1 33h-4.4v-4.4h4.4V33zm0-8.8h-4.4V11h4.4v13.2z"/>
+</svg>


### PR DESCRIPTION
### Modified

- SVGs are now implemented as background images (warning signs) or inline HTML without sprite setup (custom checkboxes and radio buttons)

### New

- Render default hidden label for a page in multi-page-setup form framework if no label is added via backend (page 1, page 2 etc.)
- Add class to visible error navigation in php-server-side validation powermail setup for better styling options